### PR TITLE
Dev lu daley/add table component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,6 @@ log.txt
 *.sublime-project
 *.sublime-workspace
 
-.history/
 .stencil/
 .idea/
 .vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ log.txt
 *.sublime-project
 *.sublime-workspace
 
+.history/
 .stencil/
 .idea/
 .vscode/

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spec-ods",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/custom-elements/index.js",

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -26,6 +26,10 @@ export namespace Components {
          */
         "middle": string;
     }
+    interface OdsTableBasic {
+        "class": string;
+        "headless": boolean;
+    }
     interface PlainButton {
     }
 }
@@ -42,6 +46,12 @@ declare global {
         prototype: HTMLMyComponentElement;
         new (): HTMLMyComponentElement;
     };
+    interface HTMLOdsTableBasicElement extends Components.OdsTableBasic, HTMLStencilElement {
+    }
+    var HTMLOdsTableBasicElement: {
+        prototype: HTMLOdsTableBasicElement;
+        new (): HTMLOdsTableBasicElement;
+    };
     interface HTMLPlainButtonElement extends Components.PlainButton, HTMLStencilElement {
     }
     var HTMLPlainButtonElement: {
@@ -51,6 +61,7 @@ declare global {
     interface HTMLElementTagNameMap {
         "accordion-button": HTMLAccordionButtonElement;
         "my-component": HTMLMyComponentElement;
+        "ods-table-basic": HTMLOdsTableBasicElement;
         "plain-button": HTMLPlainButtonElement;
     }
 }
@@ -76,11 +87,16 @@ declare namespace LocalJSX {
          */
         "middle"?: string;
     }
+    interface OdsTableBasic {
+        "class"?: string;
+        "headless"?: boolean;
+    }
     interface PlainButton {
     }
     interface IntrinsicElements {
         "accordion-button": AccordionButton;
         "my-component": MyComponent;
+        "ods-table-basic": OdsTableBasic;
         "plain-button": PlainButton;
     }
 }
@@ -90,6 +106,7 @@ declare module "@stencil/core" {
         interface IntrinsicElements {
             "accordion-button": LocalJSX.AccordionButton & JSXBase.HTMLAttributes<HTMLAccordionButtonElement>;
             "my-component": LocalJSX.MyComponent & JSXBase.HTMLAttributes<HTMLMyComponentElement>;
+            "ods-table-basic": LocalJSX.OdsTableBasic & JSXBase.HTMLAttributes<HTMLOdsTableBasicElement>;
             "plain-button": LocalJSX.PlainButton & JSXBase.HTMLAttributes<HTMLPlainButtonElement>;
         }
     }

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -38,6 +38,14 @@ export namespace Components {
         "class": string;
         "headless": boolean;
     }
+    interface OdsTableFoot {
+        "class": string;
+        "headless": boolean;
+    }
+    interface OdsTableFooter {
+        "class": string;
+        "headless": boolean;
+    }
     interface OdsTableHeader {
         "class": string;
         "headless": boolean;
@@ -84,6 +92,18 @@ declare global {
         prototype: HTMLOdsTableDataElement;
         new (): HTMLOdsTableDataElement;
     };
+    interface HTMLOdsTableFootElement extends Components.OdsTableFoot, HTMLStencilElement {
+    }
+    var HTMLOdsTableFootElement: {
+        prototype: HTMLOdsTableFootElement;
+        new (): HTMLOdsTableFootElement;
+    };
+    interface HTMLOdsTableFooterElement extends Components.OdsTableFooter, HTMLStencilElement {
+    }
+    var HTMLOdsTableFooterElement: {
+        prototype: HTMLOdsTableFooterElement;
+        new (): HTMLOdsTableFooterElement;
+    };
     interface HTMLOdsTableHeaderElement extends Components.OdsTableHeader, HTMLStencilElement {
     }
     var HTMLOdsTableHeaderElement: {
@@ -114,6 +134,8 @@ declare global {
         "ods-table-basic": HTMLOdsTableBasicElement;
         "ods-table-body": HTMLOdsTableBodyElement;
         "ods-table-data": HTMLOdsTableDataElement;
+        "ods-table-foot": HTMLOdsTableFootElement;
+        "ods-table-footer": HTMLOdsTableFooterElement;
         "ods-table-header": HTMLOdsTableHeaderElement;
         "ods-table-row": HTMLOdsTableRowElement;
         "ods-table-thead": HTMLOdsTableTheadElement;
@@ -154,6 +176,14 @@ declare namespace LocalJSX {
         "class"?: string;
         "headless"?: boolean;
     }
+    interface OdsTableFoot {
+        "class"?: string;
+        "headless"?: boolean;
+    }
+    interface OdsTableFooter {
+        "class"?: string;
+        "headless"?: boolean;
+    }
     interface OdsTableHeader {
         "class"?: string;
         "headless"?: boolean;
@@ -174,6 +204,8 @@ declare namespace LocalJSX {
         "ods-table-basic": OdsTableBasic;
         "ods-table-body": OdsTableBody;
         "ods-table-data": OdsTableData;
+        "ods-table-foot": OdsTableFoot;
+        "ods-table-footer": OdsTableFooter;
         "ods-table-header": OdsTableHeader;
         "ods-table-row": OdsTableRow;
         "ods-table-thead": OdsTableThead;
@@ -189,6 +221,8 @@ declare module "@stencil/core" {
             "ods-table-basic": LocalJSX.OdsTableBasic & JSXBase.HTMLAttributes<HTMLOdsTableBasicElement>;
             "ods-table-body": LocalJSX.OdsTableBody & JSXBase.HTMLAttributes<HTMLOdsTableBodyElement>;
             "ods-table-data": LocalJSX.OdsTableData & JSXBase.HTMLAttributes<HTMLOdsTableDataElement>;
+            "ods-table-foot": LocalJSX.OdsTableFoot & JSXBase.HTMLAttributes<HTMLOdsTableFootElement>;
+            "ods-table-footer": LocalJSX.OdsTableFooter & JSXBase.HTMLAttributes<HTMLOdsTableFooterElement>;
             "ods-table-header": LocalJSX.OdsTableHeader & JSXBase.HTMLAttributes<HTMLOdsTableHeaderElement>;
             "ods-table-row": LocalJSX.OdsTableRow & JSXBase.HTMLAttributes<HTMLOdsTableRowElement>;
             "ods-table-thead": LocalJSX.OdsTableThead & JSXBase.HTMLAttributes<HTMLOdsTableTheadElement>;

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -30,6 +30,18 @@ export namespace Components {
         "class": string;
         "headless": boolean;
     }
+    interface OdsTableData {
+        "class": string;
+        "headless": boolean;
+    }
+    interface OdsTableHeader {
+        "class": string;
+        "headless": boolean;
+    }
+    interface OdsTableRow {
+        "class": string;
+        "headless": boolean;
+    }
     interface PlainButton {
     }
 }
@@ -52,6 +64,24 @@ declare global {
         prototype: HTMLOdsTableBasicElement;
         new (): HTMLOdsTableBasicElement;
     };
+    interface HTMLOdsTableDataElement extends Components.OdsTableData, HTMLStencilElement {
+    }
+    var HTMLOdsTableDataElement: {
+        prototype: HTMLOdsTableDataElement;
+        new (): HTMLOdsTableDataElement;
+    };
+    interface HTMLOdsTableHeaderElement extends Components.OdsTableHeader, HTMLStencilElement {
+    }
+    var HTMLOdsTableHeaderElement: {
+        prototype: HTMLOdsTableHeaderElement;
+        new (): HTMLOdsTableHeaderElement;
+    };
+    interface HTMLOdsTableRowElement extends Components.OdsTableRow, HTMLStencilElement {
+    }
+    var HTMLOdsTableRowElement: {
+        prototype: HTMLOdsTableRowElement;
+        new (): HTMLOdsTableRowElement;
+    };
     interface HTMLPlainButtonElement extends Components.PlainButton, HTMLStencilElement {
     }
     var HTMLPlainButtonElement: {
@@ -62,6 +92,9 @@ declare global {
         "accordion-button": HTMLAccordionButtonElement;
         "my-component": HTMLMyComponentElement;
         "ods-table-basic": HTMLOdsTableBasicElement;
+        "ods-table-data": HTMLOdsTableDataElement;
+        "ods-table-header": HTMLOdsTableHeaderElement;
+        "ods-table-row": HTMLOdsTableRowElement;
         "plain-button": HTMLPlainButtonElement;
     }
 }
@@ -91,12 +124,27 @@ declare namespace LocalJSX {
         "class"?: string;
         "headless"?: boolean;
     }
+    interface OdsTableData {
+        "class"?: string;
+        "headless"?: boolean;
+    }
+    interface OdsTableHeader {
+        "class"?: string;
+        "headless"?: boolean;
+    }
+    interface OdsTableRow {
+        "class"?: string;
+        "headless"?: boolean;
+    }
     interface PlainButton {
     }
     interface IntrinsicElements {
         "accordion-button": AccordionButton;
         "my-component": MyComponent;
         "ods-table-basic": OdsTableBasic;
+        "ods-table-data": OdsTableData;
+        "ods-table-header": OdsTableHeader;
+        "ods-table-row": OdsTableRow;
         "plain-button": PlainButton;
     }
 }
@@ -107,6 +155,9 @@ declare module "@stencil/core" {
             "accordion-button": LocalJSX.AccordionButton & JSXBase.HTMLAttributes<HTMLAccordionButtonElement>;
             "my-component": LocalJSX.MyComponent & JSXBase.HTMLAttributes<HTMLMyComponentElement>;
             "ods-table-basic": LocalJSX.OdsTableBasic & JSXBase.HTMLAttributes<HTMLOdsTableBasicElement>;
+            "ods-table-data": LocalJSX.OdsTableData & JSXBase.HTMLAttributes<HTMLOdsTableDataElement>;
+            "ods-table-header": LocalJSX.OdsTableHeader & JSXBase.HTMLAttributes<HTMLOdsTableHeaderElement>;
+            "ods-table-row": LocalJSX.OdsTableRow & JSXBase.HTMLAttributes<HTMLOdsTableRowElement>;
             "plain-button": LocalJSX.PlainButton & JSXBase.HTMLAttributes<HTMLPlainButtonElement>;
         }
     }

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -30,6 +30,10 @@ export namespace Components {
         "class": string;
         "headless": boolean;
     }
+    interface OdsTableBody {
+        "class": string;
+        "headless": boolean;
+    }
     interface OdsTableData {
         "class": string;
         "headless": boolean;
@@ -39,6 +43,10 @@ export namespace Components {
         "headless": boolean;
     }
     interface OdsTableRow {
+        "class": string;
+        "headless": boolean;
+    }
+    interface OdsTableThead {
         "class": string;
         "headless": boolean;
     }
@@ -64,6 +72,12 @@ declare global {
         prototype: HTMLOdsTableBasicElement;
         new (): HTMLOdsTableBasicElement;
     };
+    interface HTMLOdsTableBodyElement extends Components.OdsTableBody, HTMLStencilElement {
+    }
+    var HTMLOdsTableBodyElement: {
+        prototype: HTMLOdsTableBodyElement;
+        new (): HTMLOdsTableBodyElement;
+    };
     interface HTMLOdsTableDataElement extends Components.OdsTableData, HTMLStencilElement {
     }
     var HTMLOdsTableDataElement: {
@@ -82,6 +96,12 @@ declare global {
         prototype: HTMLOdsTableRowElement;
         new (): HTMLOdsTableRowElement;
     };
+    interface HTMLOdsTableTheadElement extends Components.OdsTableThead, HTMLStencilElement {
+    }
+    var HTMLOdsTableTheadElement: {
+        prototype: HTMLOdsTableTheadElement;
+        new (): HTMLOdsTableTheadElement;
+    };
     interface HTMLPlainButtonElement extends Components.PlainButton, HTMLStencilElement {
     }
     var HTMLPlainButtonElement: {
@@ -92,9 +112,11 @@ declare global {
         "accordion-button": HTMLAccordionButtonElement;
         "my-component": HTMLMyComponentElement;
         "ods-table-basic": HTMLOdsTableBasicElement;
+        "ods-table-body": HTMLOdsTableBodyElement;
         "ods-table-data": HTMLOdsTableDataElement;
         "ods-table-header": HTMLOdsTableHeaderElement;
         "ods-table-row": HTMLOdsTableRowElement;
+        "ods-table-thead": HTMLOdsTableTheadElement;
         "plain-button": HTMLPlainButtonElement;
     }
 }
@@ -124,6 +146,10 @@ declare namespace LocalJSX {
         "class"?: string;
         "headless"?: boolean;
     }
+    interface OdsTableBody {
+        "class"?: string;
+        "headless"?: boolean;
+    }
     interface OdsTableData {
         "class"?: string;
         "headless"?: boolean;
@@ -136,15 +162,21 @@ declare namespace LocalJSX {
         "class"?: string;
         "headless"?: boolean;
     }
+    interface OdsTableThead {
+        "class"?: string;
+        "headless"?: boolean;
+    }
     interface PlainButton {
     }
     interface IntrinsicElements {
         "accordion-button": AccordionButton;
         "my-component": MyComponent;
         "ods-table-basic": OdsTableBasic;
+        "ods-table-body": OdsTableBody;
         "ods-table-data": OdsTableData;
         "ods-table-header": OdsTableHeader;
         "ods-table-row": OdsTableRow;
+        "ods-table-thead": OdsTableThead;
         "plain-button": PlainButton;
     }
 }
@@ -155,9 +187,11 @@ declare module "@stencil/core" {
             "accordion-button": LocalJSX.AccordionButton & JSXBase.HTMLAttributes<HTMLAccordionButtonElement>;
             "my-component": LocalJSX.MyComponent & JSXBase.HTMLAttributes<HTMLMyComponentElement>;
             "ods-table-basic": LocalJSX.OdsTableBasic & JSXBase.HTMLAttributes<HTMLOdsTableBasicElement>;
+            "ods-table-body": LocalJSX.OdsTableBody & JSXBase.HTMLAttributes<HTMLOdsTableBodyElement>;
             "ods-table-data": LocalJSX.OdsTableData & JSXBase.HTMLAttributes<HTMLOdsTableDataElement>;
             "ods-table-header": LocalJSX.OdsTableHeader & JSXBase.HTMLAttributes<HTMLOdsTableHeaderElement>;
             "ods-table-row": LocalJSX.OdsTableRow & JSXBase.HTMLAttributes<HTMLOdsTableRowElement>;
+            "ods-table-thead": LocalJSX.OdsTableThead & JSXBase.HTMLAttributes<HTMLOdsTableTheadElement>;
             "plain-button": LocalJSX.PlainButton & JSXBase.HTMLAttributes<HTMLPlainButtonElement>;
         }
     }

--- a/src/components/ods-tables/table-basic/ods-table-basic.scss
+++ b/src/components/ods-tables/table-basic/ods-table-basic.scss
@@ -1,0 +1,8 @@
+.ods-table-basic-default {
+  font-family: 'Courier New', Courier, monospace;
+  // font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif
+// font-family: Arial, Helvetica, sans-serif;
+// color: rgb(136, 255, 0);
+ text-decoration: line-through;
+
+}

--- a/src/components/ods-tables/table-basic/ods-table-basic.scss
+++ b/src/components/ods-tables/table-basic/ods-table-basic.scss
@@ -1,4 +1,5 @@
-.ods-table-basic-default {
+// .ods-table-basic-default {
+:host {
   // font-family: 'Courier New', Courier, monospace;
   // font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif
 font-family: Arial, Helvetica, sans-serif;

--- a/src/components/ods-tables/table-basic/ods-table-basic.scss
+++ b/src/components/ods-tables/table-basic/ods-table-basic.scss
@@ -1,8 +1,9 @@
 .ods-table-basic-default {
-  font-family: 'Courier New', Courier, monospace;
+  // font-family: 'Courier New', Courier, monospace;
   // font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif
-// font-family: Arial, Helvetica, sans-serif;
+font-family: Arial, Helvetica, sans-serif;
 // color: rgb(136, 255, 0);
- text-decoration: line-through;
+//  text-decoration: line-through;
+ text-decoration: underline;
 
 }

--- a/src/components/ods-tables/table-basic/ods-table-basic.tsx
+++ b/src/components/ods-tables/table-basic/ods-table-basic.tsx
@@ -1,0 +1,45 @@
+import { Component, Host, Prop, h } from '@stencil/core';
+
+@Component({
+  tag: 'ods-table-basic',
+  styleUrl: 'ods-table-basic.scss',
+  shadow: true
+})
+
+export class ODSTableBasic {
+  @Prop() class: string;
+  @Prop() headless: boolean;
+
+  render() {
+    // console.log(window.headlessmode)
+    // console.log(window)
+    const defaultClass = 'ods-table-basic-default'
+    const currentClass = this.headless
+      ? this.class : `${this.class} ${defaultClass}`
+    return (
+      <Host>
+        {/* <div> */}
+        <table class={currentClass}
+        // style={{
+        // }}
+        >
+          {/* <tr>
+            <th>Person 1</th>
+            <th>Person 2</th>
+            <th>Person 3</th>
+            <th>Person 3</th>
+            <th>Person 3</th>
+            <th>Person 3</th>
+          </tr> */}
+          <tr>
+            {/* <td></td>
+            <td>USD</td>
+            <td>EUR</td> */}
+            <slot />
+          </tr>
+        </table>
+        {/* </div> */}
+      </Host >
+    )
+  }
+}

--- a/src/components/ods-tables/table-basic/ods-table-basic.tsx
+++ b/src/components/ods-tables/table-basic/ods-table-basic.tsx
@@ -1,4 +1,6 @@
 import { Component, Host, Prop, h } from '@stencil/core';
+// import ods-table-row from '../table-components/table-row/ods-table-row';
+// import 'ods-table-row'; //from '../table-components/table-row/ods-table-row';
 
 @Component({
   tag: 'ods-table-basic',

--- a/src/components/ods-tables/table-components/table-body/ods-table-body.scss
+++ b/src/components/ods-tables/table-components/table-body/ods-table-body.scss
@@ -1,0 +1,3 @@
+:host {
+  display: contents;
+}

--- a/src/components/ods-tables/table-components/table-body/ods-table-body.tsx
+++ b/src/components/ods-tables/table-components/table-body/ods-table-body.tsx
@@ -1,29 +1,31 @@
 import { Component, Host, Prop, h } from '@stencil/core';
 
 @Component({
-  tag: 'ods-table-row',
-  styleUrl: 'ods-table-row.scss',
+  tag: 'ods-table-body',
+  styleUrl: 'ods-table-body.scss',
   shadow: true
 })
 
-export class ODSTableRow {
+export class ODSTableBody {
   @Prop() class: string;
   @Prop() headless: boolean;
 
   render() {
     // console.log(window.headlessmode)
     // console.log(window)
-    const defaultClass = 'ods-table-row-default'
+    const defaultClass = 'ods-table-body-default'
     // const currentClass = this.headless
     // ? this.class : `${this.class} ${defaultClass}`
     return (
+      // <div>
       <Host>
-        <tr>
+        {/* <table> */}
+        <tbody>
           <slot />
-        </tr>
-        {/* note: line break is being used until we can figure out why the <tr> tag won't create a new line/row */}
-        {/* <br /> */}
+        </tbody>
+        {/* </table> */}
       </Host >
+      // </div>
     )
   }
 }

--- a/src/components/ods-tables/table-components/table-data/ods-table-data.scss
+++ b/src/components/ods-tables/table-components/table-data/ods-table-data.scss
@@ -1,0 +1,3 @@
+:host {
+  display: contents;
+}

--- a/src/components/ods-tables/table-components/table-data/ods-table-data.tsx
+++ b/src/components/ods-tables/table-components/table-data/ods-table-data.tsx
@@ -1,0 +1,32 @@
+import { Component, Host, Prop, h } from '@stencil/core';
+
+@Component({
+  tag: 'ods-table-data',
+  styleUrl: 'ods-table-data.scss',
+  shadow: true
+})
+
+export class ODSTableData {
+  @Prop() class: string;
+  @Prop() headless: boolean;
+
+  render() {
+    // console.log(window.headlessmode)
+    // console.log(window)
+    const defaultClass = 'ods-table-data-default'
+    // const currentClass = this.headless
+    // ? this.class : `${this.class} ${defaultClass}`
+    return (
+      // <div>
+      <Host>
+        {/* <table> */}
+        <td>
+          <slot />
+        </td>
+        {/* </table> */}
+      </Host >
+      // </div>
+    )
+  }
+}
+

--- a/src/components/ods-tables/table-components/table-foot/ods-table-foot.scss
+++ b/src/components/ods-tables/table-components/table-foot/ods-table-foot.scss
@@ -1,0 +1,3 @@
+:host {
+  display: contents;
+}

--- a/src/components/ods-tables/table-components/table-foot/ods-table-foot.tsx
+++ b/src/components/ods-tables/table-components/table-foot/ods-table-foot.tsx
@@ -1,0 +1,32 @@
+import { Component, Host, Prop, h } from '@stencil/core';
+
+@Component({
+  tag: 'ods-table-foot',
+  styleUrl: 'ods-table-foot.scss',
+  shadow: true
+})
+
+export class ODSTableFoot {
+  @Prop() class: string;
+  @Prop() headless: boolean;
+
+  render() {
+    // console.log(window.headlessmode)
+    // console.log(window)
+    const defaultClass = 'ods-table-foot-default'
+    // const currentClass = this.headless
+    // ? this.class : `${this.class} ${defaultClass}`
+    return (
+      // <div>
+      <Host>
+        {/* <table> */}
+        <tfoot>
+          <slot />
+        </tfoot>
+        {/* </table> */}
+      </Host >
+      // </div>
+    )
+  }
+}
+

--- a/src/components/ods-tables/table-components/table-header/ods-table-header.scss
+++ b/src/components/ods-tables/table-components/table-header/ods-table-header.scss
@@ -1,0 +1,3 @@
+:host {
+  display: contents;
+}

--- a/src/components/ods-tables/table-components/table-header/ods-table-header.tsx
+++ b/src/components/ods-tables/table-components/table-header/ods-table-header.tsx
@@ -1,0 +1,32 @@
+import { Component, Host, Prop, h } from '@stencil/core';
+
+@Component({
+  tag: 'ods-table-header',
+  styleUrl: 'ods-table-header.scss',
+  shadow: true
+})
+
+export class ODSTableHeader {
+  @Prop() class: string;
+  @Prop() headless: boolean;
+
+  render() {
+    // console.log(window.headlessmode)
+    // console.log(window)
+    const defaultClass = 'ods-table-header-default'
+    // const currentClass = this.headless
+    // ? this.class : `${this.class} ${defaultClass}`
+    return (
+      // <div>
+      <Host>
+        {/* <table> */}
+        <th>
+          <slot />
+        </th>
+        {/* </table> */}
+      </Host >
+      // </div>
+    )
+  }
+}
+

--- a/src/components/ods-tables/table-components/table-row/ods-table-row.scss
+++ b/src/components/ods-tables/table-components/table-row/ods-table-row.scss
@@ -1,0 +1,3 @@
+:host {
+  display: contents;
+}

--- a/src/components/ods-tables/table-components/table-row/ods-table-row.tsx
+++ b/src/components/ods-tables/table-components/table-row/ods-table-row.tsx
@@ -1,0 +1,30 @@
+import { Component, Host, Prop, h } from '@stencil/core';
+
+@Component({
+  tag: 'ods-table-row',
+  styleUrl: 'ods-table-row.scss',
+  shadow: true
+})
+
+export class ODSTableRow {
+  @Prop() class: string;
+  @Prop() headless: boolean;
+
+  render() {
+    // console.log(window.headlessmode)
+    // console.log(window)
+    const defaultClass = 'ods-table-row-default'
+    // const currentClass = this.headless
+    // ? this.class : `${this.class} ${defaultClass}`
+    return (
+      <Host>
+        <tr>
+          <slot />
+        </tr>
+        {/* note: line break is being used until we can figure out why the <tr> tag won't create a new line/row */}
+        <br />
+      </Host >
+    )
+  }
+}
+

--- a/src/components/ods-tables/table-components/table-thead/ods-table-thead.scss
+++ b/src/components/ods-tables/table-components/table-thead/ods-table-thead.scss
@@ -1,0 +1,3 @@
+:host {
+  display: contents;
+}

--- a/src/components/ods-tables/table-components/table-thead/ods-table-thead.tsx
+++ b/src/components/ods-tables/table-components/table-thead/ods-table-thead.tsx
@@ -1,29 +1,31 @@
 import { Component, Host, Prop, h } from '@stencil/core';
 
 @Component({
-  tag: 'ods-table-row',
-  styleUrl: 'ods-table-row.scss',
+  tag: 'ods-table-thead',
+  styleUrl: 'ods-table-thead.scss',
   shadow: true
 })
 
-export class ODSTableRow {
+export class ODSTableBody {
   @Prop() class: string;
   @Prop() headless: boolean;
 
   render() {
     // console.log(window.headlessmode)
     // console.log(window)
-    const defaultClass = 'ods-table-row-default'
+    const defaultClass = 'ods-table-thead-default'
     // const currentClass = this.headless
     // ? this.class : `${this.class} ${defaultClass}`
     return (
+      // <div>
       <Host>
-        <tr>
+        {/* <table> */}
+        <thead>
           <slot />
-        </tr>
-        {/* note: line break is being used until we can figure out why the <tr> tag won't create a new line/row */}
-        {/* <br /> */}
+        </thead>
+        {/* </table> */}
       </Host >
+      // </div>
     )
   }
 }

--- a/src/index.html
+++ b/src/index.html
@@ -29,6 +29,9 @@
 
   <!-- <ods-table-basic headless="true" class='test-classes'> -->
   <!-- <ods-table-basic class='test-classes'> -->
+  <h1>
+    Placeholder: ODS-table-basic
+  </h1>
   <ods-table-basic class='test-classes'>
     <th>
       Placeholder: ods-table-basic
@@ -38,9 +41,34 @@
       <th>Person 1</th>
       <th>Person 2</th>
       <th>Person 3</th>
-
+      <th>Person 4</th>
+      <th>Person 5</th>
+      <th>Person 6</th>
     </tr>
-    WORDS HERE
+    <tr>
+      <td>Claudia</td>
+      <td>Frank</td>
+      <td>Carolyn</td>
+      <td>Lee</td>
+      <td>Nicole</td>
+      <td>Janet</td>
+    </tr>
+    <tr></tr>
+    <tr>
+      <td>45</td>
+      <td>55</td>
+      <td>22</td>
+      <td>45</td>
+      <td>62</td>
+      <td>61</td>
+    </tr>
+    <!-- </table> -->
+  </ods-table-basic>
+
+  <h1>
+    Placeholder: non-ODS-table
+  </h1>
+  <table>
     <tr>
       <th>Person 1</th>
       <th>Person 2</th>
@@ -50,43 +78,21 @@
       <th>Person 6</th>
     </tr>
     <tr>
-      <td>WOW</td>
-    </tr>
-    <tr>
       <td>Claudia</td>
       <td>Frank</td>
-      <td>Carolyn/td>
+      <td>Carolyn</td>
       <td>Lee</td>
       <td>Nicole</td>
       <td>Janet</td>
     </tr>
     <tr></tr>
     <tr>
-      <td>16</td>
-      <td>14</td>
-      <td>10</td>
-      <td>10</td>
-      <td>10</td>
-      <td>10</td>
-    </tr>
-    <!-- </table> -->
-  </ods-table-basic>
-
-  <table>
-    <tr>
-      <th>Person 1</th>
-      <th>Person 2</th>
-      <th>Person 3</th>
-    </tr>
-    <tr>
-      <td>Emil</td>
-      <td>Tobias</td>
-      <td>Linus</td>
-    </tr>
-    <tr>
-      <td>16</td>
-      <td>14</td>
-      <td>10</td>
+      <td>45</td>
+      <td>55</td>
+      <td>22</td>
+      <td>45</td>
+      <td>62</td>
+      <td>61</td>
     </tr>
   </table>
 </body>

--- a/src/index.html
+++ b/src/index.html
@@ -12,6 +12,11 @@
       color: rgb(255, 0, 183);
       font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif
     }
+
+    /*
+    :host {
+      display: contents;
+    } */
   </style>
   <script type="module" src="/build/spec-ods.esm.js"></script>
 
@@ -63,7 +68,16 @@
         <ods-table-data>61</ods-table-data>
       </ods-table-row>
     </ods-table-body>
-    <!-- </table> -->
+    <ods-table-footer>
+      <ods-table-row>
+        <ods-table-data>15</ods-table-data>
+        <ods-table-data>25</ods-table-data>
+        <ods-table-data>32</ods-table-data>
+        <ods-table-data>41</ods-table-data>
+        <ods-table-data>51</ods-table-data>
+        <ods-table-data>64</ods-table-data>
+      </ods-table-row>
+    </ods-table-footer>
   </ods-table-basic>
 
   <h1>
@@ -87,14 +101,6 @@
       <td>Janet</td>
     </tr>
     <tr></tr>
-    <tr>
-      <td>45</td>
-      <td>55</td>
-      <td>22</td>
-      <td>45</td>
-      <td>62</td>
-      <td>61</td>
-    </tr>
     <tr>
       <td>45</td>
       <td>55</td>

--- a/src/index.html
+++ b/src/index.html
@@ -34,31 +34,35 @@
     Placeholder: ODS-table-basic
   </h1>
   <ods-table-basic class='test-classes'>
-    <ods-table-row>
-      <ods-table-header>Person 1</ods-table-header>
-      <ods-table-header>Person 2</ods-table-header>
-      <ods-table-header>Person 3</ods-table-header>
-      <ods-table-header>Person 4</ods-table-header>
-      <ods-table-header>Person 5</ods-table-header>
-      <ods-table-header>Person 6</ods-table-header>
-    </ods-table-row>
-    <ods-table-row>
-      <ods-table-data>Claudia</ods-table-data>
-      <ods-table-data>Frank</ods-table-data>
-      <ods-table-data>Carolyn</ods-table-data>
-      <ods-table-data>Lee</ods-table-data>
-      <ods-table-data>Nicole</ods-table-data>
-      <ods-table-data>Janet</ods-table-data>
-    </ods-table-row>
+    <ods-table-thead>
+      <ods-table-row>
+        <ods-table-header>Person 1</ods-table-header>
+        <ods-table-header>Person 2</ods-table-header>
+        <ods-table-header>Person 3</ods-table-header>
+        <ods-table-header>Person 4</ods-table-header>
+        <ods-table-header>Person 5</ods-table-header>
+        <ods-table-header>Person 6</ods-table-header>
+      </ods-table-row>
+    </ods-table-thead>
+    <ods-table-body>
+      <ods-table-row>
+        <ods-table-data>Claudia</ods-table-data>
+        <ods-table-data>Frank</ods-table-data>
+        <ods-table-data>Carolyn</ods-table-data>
+        <ods-table-data>Lee</ods-table-data>
+        <ods-table-data>Nicole</ods-table-data>
+        <ods-table-data>Janet</ods-table-data>
+      </ods-table-row>
 
-    <ods-table-row>
-      <ods-table-data>45</ods-table-data>
-      <ods-table-data>55</ods-table-data>
-      <ods-table-data>22</ods-table-data>
-      <ods-table-data>45</ods-table-data>
-      <ods-table-data>62</ods-table-data>
-      <ods-table-data>61</ods-table-data>
-    </ods-table-row>
+      <ods-table-row>
+        <ods-table-data>45</ods-table-data>
+        <ods-table-data>55</ods-table-data>
+        <ods-table-data>22</ods-table-data>
+        <ods-table-data>45</ods-table-data>
+        <ods-table-data>62</ods-table-data>
+        <ods-table-data>61</ods-table-data>
+      </ods-table-row>
+    </ods-table-body>
     <!-- </table> -->
   </ods-table-basic>
 

--- a/src/index.html
+++ b/src/index.html
@@ -1,24 +1,94 @@
 <!DOCTYPE html>
 <html dir="ltr" lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0" />
-    <title>Stencil Component Starter</title>
 
-    <script type="module" src="/build/spec-ods.esm.js"></script>
-    <script nomodule src="/build/spec-ods.js"></script>
-  </head>
-  <body>
-    <accordion-button width='75%'
-      label='SPEC Accordion Button'
-      color='blue'
-      description="Articulate the buttons how you wish. If changes are made to this stencil, please update with a newer version before publishing">
-    </accordion-button>
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0" />
+  <title>Stencil Component Starter</title>
 
-    <plain-button
-      name="plain-button"
-    > EAT STUFF
-    </plain-button>
+  <style>
+    .test-classes {
+      font-size: 22px;
+      color: rgb(255, 0, 183);
+      font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif
+    }
+  </style>
+  <script type="module" src="/build/spec-ods.esm.js"></script>
 
-  </body>
+  <script> window.headlessmode = true</script>
+  <script nomodule src="/build/spec-ods.js"></script>
+</head>
+
+<body>
+  <accordion-button width='75%' label='SPEC Accordion Button' color='blue'
+    description="Articulate the buttons how you wish. If changes are made to this stencil, please update with a newer version before publishing">
+  </accordion-button>
+
+  <plain-button name="plain-button"> Placeholder: ODS-plain-button
+  </plain-button>
+
+  <!-- <ods-table-basic headless="true" class='test-classes'> -->
+  <!-- <ods-table-basic class='test-classes'> -->
+  <ods-table-basic class='test-classes'>
+    <th>
+      Placeholder: ods-table-basic
+    </th>
+    <!-- <table> -->
+    <tr>
+      <th>Person 1</th>
+      <th>Person 2</th>
+      <th>Person 3</th>
+
+    </tr>
+    WORDS HERE
+    <tr>
+      <th>Person 1</th>
+      <th>Person 2</th>
+      <th>Person 3</th>
+      <th>Person 4</th>
+      <th>Person 5</th>
+      <th>Person 6</th>
+    </tr>
+    <tr>
+      <td>WOW</td>
+    </tr>
+    <tr>
+      <td>Claudia</td>
+      <td>Frank</td>
+      <td>Carolyn/td>
+      <td>Lee</td>
+      <td>Nicole</td>
+      <td>Janet</td>
+    </tr>
+    <tr></tr>
+    <tr>
+      <td>16</td>
+      <td>14</td>
+      <td>10</td>
+      <td>10</td>
+      <td>10</td>
+      <td>10</td>
+    </tr>
+    <!-- </table> -->
+  </ods-table-basic>
+
+  <table>
+    <tr>
+      <th>Person 1</th>
+      <th>Person 2</th>
+      <th>Person 3</th>
+    </tr>
+    <tr>
+      <td>Emil</td>
+      <td>Tobias</td>
+      <td>Linus</td>
+    </tr>
+    <tr>
+      <td>16</td>
+      <td>14</td>
+      <td>10</td>
+    </tr>
+  </table>
+</body>
+
 </html>

--- a/src/index.html
+++ b/src/index.html
@@ -29,14 +29,43 @@
 
   <!-- <ods-table-basic headless="true" class='test-classes'> -->
   <!-- <ods-table-basic class='test-classes'> -->
+
   <h1>
     Placeholder: ODS-table-basic
   </h1>
   <ods-table-basic class='test-classes'>
-    <th>
-      Placeholder: ods-table-basic
-    </th>
-    <!-- <table> -->
+    <ods-table-row>
+      <ods-table-header>Person 1</ods-table-header>
+      <ods-table-header>Person 2</ods-table-header>
+      <ods-table-header>Person 3</ods-table-header>
+      <ods-table-header>Person 4</ods-table-header>
+      <ods-table-header>Person 5</ods-table-header>
+      <ods-table-header>Person 6</ods-table-header>
+    </ods-table-row>
+    <ods-table-row>
+      <ods-table-data>Claudia</ods-table-data>
+      <ods-table-data>Frank</ods-table-data>
+      <ods-table-data>Carolyn</ods-table-data>
+      <ods-table-data>Lee</ods-table-data>
+      <ods-table-data>Nicole</ods-table-data>
+      <ods-table-data>Janet</ods-table-data>
+    </ods-table-row>
+
+    <ods-table-row>
+      <ods-table-data>45</ods-table-data>
+      <ods-table-data>55</ods-table-data>
+      <ods-table-data>22</ods-table-data>
+      <ods-table-data>45</ods-table-data>
+      <ods-table-data>62</ods-table-data>
+      <ods-table-data>61</ods-table-data>
+    </ods-table-row>
+    <!-- </table> -->
+  </ods-table-basic>
+
+  <h1>
+    Placeholder: standard-html-table
+  </h1>
+  <table>
     <tr>
       <th>Person 1</th>
       <th>Person 2</th>
@@ -62,30 +91,6 @@
       <td>62</td>
       <td>61</td>
     </tr>
-    <!-- </table> -->
-  </ods-table-basic>
-
-  <h1>
-    Placeholder: non-ODS-table
-  </h1>
-  <table>
-    <tr>
-      <th>Person 1</th>
-      <th>Person 2</th>
-      <th>Person 3</th>
-      <th>Person 4</th>
-      <th>Person 5</th>
-      <th>Person 6</th>
-    </tr>
-    <tr>
-      <td>Claudia</td>
-      <td>Frank</td>
-      <td>Carolyn</td>
-      <td>Lee</td>
-      <td>Nicole</td>
-      <td>Janet</td>
-    </tr>
-    <tr></tr>
     <tr>
       <td>45</td>
       <td>55</td>


### PR DESCRIPTION
Hey Team, 

As of now we have the `ODS-table-basic` component displaying the inline css in index.html. If the `headless` attribute == true  then the styles for the class assigned by the framework are displayed. If `headless` == false then the styles for the class AND the default styles in the `ODS-table-basic` component will display. 

The issue that we have is that the `ODS-table-basic` html tag doesn't display the way the standard html `<table>` tag displays. If anyone sees an obvious answer please share. I'll continue researching this issue. 

Please see the image below for an example of the placeholders for the `ODS-table-basic` and a standard html `<table>`. 
![image](https://user-images.githubusercontent.com/46202132/141357713-8ebdcebe-efeb-4e62-9718-571f53926bff.png)